### PR TITLE
Add GitHub contribution graph widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,28 @@ https://stats.programcx.cn/api?username=duv0-x&show_icons=true&theme=gotham&hide
 - Streak Stats: `https://streak-stats.demolab.com/?user=duv0-x&theme=dark`
 - Self-host on Vercel with own GitHub token (most reliable)
 
+### GitHub Contribution Graph
+
+**Service**: Using `github.pumbas.net` (contribution calendar widget)
+
+```html
+https://github.pumbas.net/api/contributions/duv0-x?colour=27a888&bgColour=0c1015&dotColour=98d1cc&days=365&borderRadius=10
+```
+
+**What it shows**:
+- Daily GitHub contribution activity (commits, PRs, issues, reviews)
+- Last 365 days of contributions
+- Visual "heatmap" calendar similar to GitHub profile
+
+**Customization**:
+- `colour=27a888`: Primary accent color (matches site theme)
+- `bgColour=0c1015`: Background color (matches container background)
+- `dotColour=98d1cc`: Individual day dots color (matches secondary accent)
+- `days=365`: Shows full year of contributions
+- `borderRadius=10`: Rounded corners to match site aesthetic
+
+**Note**: This widget updates dynamically as contributions are made to GitHub
+
 ## HTML Best Practices for This Site
 
 1. **Language**: Set to Spanish (`lang="es"`) but content is multilingual

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
 <div class="container stats">
     <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="Top Langs" src="https://stats.programcx.cn/api/top-langs/?username=duv0-x&layout=compact&theme=gotham&hide_border=true&langs_count=8"></a></p>
     <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="GitHub Stats" src="https://stats.programcx.cn/api?username=duv0-x&show_icons=true&theme=gotham&hide=stars,issues&show=prs_merged_percentage&hide_rank=true&hide_border=true&custom_title=GitHub%20Stats" /></a></p>
+    <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="Contributions" src="https://github.pumbas.net/api/contributions/duv0-x?colour=27a888&bgColour=0c1015&dotColour=98d1cc&days=365&borderRadius=10" /></a></p>
 </div>
 
 <div class="container social-networks">


### PR DESCRIPTION
Added the GitHub contribution calendar below the existing stats widgets.

Changes:
- index.html: Added contribution graph from github.pumbas.net
- CLAUDE.md: Documented the new widget and its customization

Features:
- Shows last 365 days of GitHub contributions
- Custom colors matching the gotham theme:
  * Primary: #27a888 (site accent color)
  * Background: #0c1015 (container background)
  * Dots: #98d1cc (secondary accent)
- Dynamic updates as new contributions are made
- 10px border radius to match site aesthetic

The contribution graph provides a visual heatmap similar to the GitHub profile page, enhancing the stats section.