### PR TITLE
Replace contribution graph with GitHub Streak Stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,27 +217,26 @@ https://stats.programcx.cn/api?username=duv0-x&show_icons=true&theme=gotham&hide
 - Streak Stats: `https://streak-stats.demolab.com/?user=duv0-x&theme=dark`
 - Self-host on Vercel with own GitHub token (most reliable)
 
-### GitHub Contribution Graph
+### GitHub Streak Stats
 
-**Service**: Using `github.pumbas.net` (contribution calendar widget)
+**Service**: Using `streak-stats.demolab.com` (contribution streak widget)
 
 ```html
-https://github.pumbas.net/api/contributions/duv0-x?colour=27a888&bgColour=0c1015&dotColour=98d1cc&days=365&borderRadius=10
+https://streak-stats.demolab.com?user=duv0-x&theme=gotham&hide_border=true&date_format=M%20j%5B%2C%20Y%5D
 ```
 
 **What it shows**:
-- Daily GitHub contribution activity (commits, PRs, issues, reviews)
-- Last 365 days of contributions
-- Visual "heatmap" calendar similar to GitHub profile
+- Current streak (consecutive days contributing)
+- Longest streak achieved
+- Total contributions
+- Mobile-friendly and responsive design
 
 **Customization**:
-- `colour=27a888`: Primary accent color (matches site theme)
-- `bgColour=0c1015`: Background color (matches container background)
-- `dotColour=98d1cc`: Individual day dots color (matches secondary accent)
-- `days=365`: Shows full year of contributions
-- `borderRadius=10`: Rounded corners to match site aesthetic
+- `theme=gotham`: Matches the site's color scheme (same as other stats)
+- `hide_border=true`: Clean integration without borders
+- `date_format`: Customized date display format
 
-**Note**: This widget updates dynamically as contributions are made to GitHub
+**Note**: This widget is more compact than the full contribution graph and displays better on mobile devices
 
 ## HTML Best Practices for This Site
 

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
 <div class="container stats">
     <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="Top Langs" src="https://stats.programcx.cn/api/top-langs/?username=duv0-x&layout=compact&theme=gotham&hide_border=true&langs_count=8"></a></p>
     <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="GitHub Stats" src="https://stats.programcx.cn/api?username=duv0-x&show_icons=true&theme=gotham&hide=stars,issues&show=prs_merged_percentage&hide_rank=true&hide_border=true&custom_title=GitHub%20Stats" /></a></p>
-    <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="Contributions" src="https://github.pumbas.net/api/contributions/duv0-x?colour=27a888&bgColour=0c1015&dotColour=98d1cc&days=365&borderRadius=10" /></a></p>
+    <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="GitHub Streak" src="https://streak-stats.demolab.com?user=duv0-x&theme=gotham&hide_border=true&date_format=M%20j%5B%2C%20Y%5D" /></a></p>
 </div>
 
 <div class="container social-networks">


### PR DESCRIPTION
Problem:
- Previous contribution calendar was too wide and displayed poorly on mobile
- Appeared very small and diminuta on mobile devices

Solution:
- Replaced with GitHub Streak Stats which is more compact and responsive
- Uses same gotham theme for consistency
- Shows current streak, longest streak, and total contributions
- Mobile-friendly design that scales better

Changes:
- index.html: Replaced contribution graph with streak stats widget
- CLAUDE.md: Updated documentation to reflect new widget

The streak stats provide better mobile UX while still showing contribution activity in a meaningful way.