### PR TITLE
Replace GitHub Stats widgets with Tech Stack badges

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,14 +192,12 @@ Before committing changes to this **static site**, verify:
 - Loaded via Google Fonts CDN
 - Preconnect to fonts.googleapis.com and fonts.gstatic.com for performance
 
-### GitHub Stats API
+### GitHub Top Languages Stats
 
 **Current Service**: Using `stats.programcx.cn` (alternative instance)
 
 ```html
 https://stats.programcx.cn/api/top-langs/?username=duv0-x&layout=compact&theme=gotham&hide_border=true&langs_count=8
-
-https://stats.programcx.cn/api?username=duv0-x&show_icons=true&theme=gotham&hide=stars,issues&show=prs_merged_percentage&hide_rank=true&hide_border=true&custom_title=GitHub Stats
 ```
 
 **Why the alternative instance?**
@@ -210,33 +208,42 @@ https://stats.programcx.cn/api?username=duv0-x&show_icons=true&theme=gotham&hide
 **Styling**:
 - Uses `gotham` theme to match site colors
 - Hides borders for cleaner integration
-- Parameters are carefully tuned - don't modify without testing
+- Shows top 8 languages in compact layout
 
-**Other Alternatives if Current Fails**:
-- GitHub Profile Trophy: `https://github-profile-trophy.vercel.app/?username=duv0-x&theme=onestar`
-- Streak Stats: `https://streak-stats.demolab.com/?user=duv0-x&theme=dark`
-- Self-host on Vercel with own GitHub token (most reliable)
+**Note**: Only the Top Languages widget is used. Other stats widgets (GitHub Stats, Streak Stats) were removed due to API reliability issues and replaced with static Tech Stack badges.
 
-### GitHub Streak Stats
+### Tech Stack Badges
 
-**Service**: Using `streak-stats.demolab.com` (contribution streak widget)
+**Service**: Using `shields.io` (static badge generator)
 
+Located in index.html lines 37-51. Displays key technologies and tools using shields.io badges.
+
+**Current Technologies**:
+- **Containers**: Docker, Kubernetes
+- **Cloud**: AWS
+- **IaC**: Terraform
+- **Languages**: Python, Go
+- **CI/CD**: GitHub Actions
+- **Monitoring**: Prometheus, Grafana
+- **OS**: Linux
+
+**Badge Format**:
 ```html
-https://streak-stats.demolab.com?user=duv0-x&theme=gotham&hide_border=true&date_format=M%20j%5B%2C%20Y%5D
+<img src="https://img.shields.io/badge/TechName-ColorHex?style=flat&logo=logoname&logoColor=white" alt="TechName"/>
 ```
 
-**What it shows**:
-- Current streak (consecutive days contributing)
-- Longest streak achieved
-- Total contributions
-- Mobile-friendly and responsive design
+**Updating Tech Stack**:
+- Add/remove badges as needed to reflect current skills
+- Use official brand colors for consistency
+- Keep logos from simple-icons.org (used by shields.io)
+- Maintain `style=flat` for clean, minimal look
+- All badges should have descriptive alt text for accessibility
 
-**Customization**:
-- `theme=gotham`: Matches the site's color scheme (same as other stats)
-- `hide_border=true`: Clean integration without borders
-- `date_format`: Customized date display format
-
-**Note**: This widget is more compact than the full contribution graph and displays better on mobile devices
+**Finding Badge URLs**:
+1. Visit https://shields.io
+2. Use format: `/badge/<LABEL>-<COLOR>?style=flat&logo=<LOGO>&logoColor=white`
+3. Find logo names at https://simpleicons.org
+4. Use official brand colors when possible
 
 ## HTML Best Practices for This Site
 

--- a/index.html
+++ b/index.html
@@ -32,8 +32,22 @@
 
 <div class="container stats">
     <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="Top Langs" src="https://stats.programcx.cn/api/top-langs/?username=duv0-x&layout=compact&theme=gotham&hide_border=true&langs_count=8"></a></p>
-    <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="GitHub Stats" src="https://stats.programcx.cn/api?username=duv0-x&show_icons=true&theme=gotham&hide=stars,issues&show=prs_merged_percentage&hide_rank=true&hide_border=true&custom_title=GitHub%20Stats" /></a></p>
-    <p> <a href="https://github.com/duv0-x" style="color: black;"><img alt="GitHub Streak" src="https://streak-stats.demolab.com?user=duv0-x&theme=gotham&hide_border=true&date_format=M%20j%5B%2C%20Y%5D" /></a></p>
+</div>
+
+<div class="container social-networks">
+    <h3>> Tech Stack</h3>
+    <p>
+        <img src="https://img.shields.io/badge/Docker-2496ED?style=flat&logo=docker&logoColor=white" alt="Docker"/>
+        <img src="https://img.shields.io/badge/Kubernetes-326CE5?style=flat&logo=kubernetes&logoColor=white" alt="Kubernetes"/>
+        <img src="https://img.shields.io/badge/AWS-232F3E?style=flat&logo=amazonwebservices&logoColor=white" alt="AWS"/>
+        <img src="https://img.shields.io/badge/Terraform-7B42BC?style=flat&logo=terraform&logoColor=white" alt="Terraform"/>
+        <img src="https://img.shields.io/badge/Python-3776AB?style=flat&logo=python&logoColor=white" alt="Python"/>
+        <img src="https://img.shields.io/badge/Go-00ADD8?style=flat&logo=go&logoColor=white" alt="Go"/>
+        <img src="https://img.shields.io/badge/GitHub_Actions-2088FF?style=flat&logo=github-actions&logoColor=white" alt="GitHub Actions"/>
+        <img src="https://img.shields.io/badge/Prometheus-E6522C?style=flat&logo=prometheus&logoColor=white" alt="Prometheus"/>
+        <img src="https://img.shields.io/badge/Grafana-F46800?style=flat&logo=grafana&logoColor=white" alt="Grafana"/>
+        <img src="https://img.shields.io/badge/Linux-FCC624?style=flat&logo=linux&logoColor=black" alt="Linux"/>
+    </p><br>
 </div>
 
 <div class="container social-networks">


### PR DESCRIPTION
Problem:
- GitHub Stats and Streak Stats widgets were unreliable (API issues)
- Streak Stats showed "Failed to retrieve contributions" error
- Both widgets experienced frequent downtime due to rate limiting

Solution:
- Removed unreliable GitHub Stats and Streak Stats widgets
- Kept only Top Languages widget (working reliably)
- Added Tech Stack section with shields.io badges
- Displays key SRE/DevOps technologies in clean, static badges

Benefits:
- No dependency on external APIs (except Top Languages)
- Always loads instantly, no failures
- Shows relevant skills: Docker, K8s, AWS, Terraform, etc.
- Mobile-friendly and responsive
- Maintainable - easy to add/remove technologies

Changes:
- index.html: Replaced stats widgets with tech stack badges
- CLAUDE.md: Updated documentation for new structure

The site now has: Top Languages (dynamic) + Tech Stack (static badges)