### PR TITLE
Style info labels and translate schedule to English

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,13 +19,13 @@
     <img src="images/x-0vub-small.jpg" alt="Duv0-x">
     </p>
     <p class="about-info">
-        Name:<br>
+        <span class="info-label">Name:</span><br>
             Duván Ballén<br><br>
-        A.k.a:<br>
+        <span class="info-label">A.k.a:</span><br>
             duv0_x<br><br>
-        Tech skills:<br>
+        <span class="info-label">Tech skills:</span><br>
             DevOps, Cloud and Platform engineering.<br><br>
-        Status:<br>
+        <span class="info-label">Status:</span><br>
             "Sr Platform Engineer @ Lulo Bank — but ping me if you have something exciting."
     </p>
 </div>
@@ -53,11 +53,11 @@
     <div id="twitch-embed"></div>
 
     <div class="stream-schedule">
-        <h4>Horario de Streams:</h4>
+        <h4>Streaming Schedule:</h4>
         <p>
-            📅 Lunes - Viernes<br>
+            📅 Monday - Friday<br>
             🕐 17:30 - 20:00 COT (UTC-05:00)<br><br>
-            📅 Sábados<br>
+            📅 Saturdays<br>
             🕐 09:00 - 13:00 COT (UTC-05:00)
         </p>
     </div>

--- a/styles.css
+++ b/styles.css
@@ -55,6 +55,10 @@ header {
     background-color: rgba(39, 168, 136, 0.1);
 }
 
+.info-label {
+    color: #27a888;
+}
+
 .stats {
     background: #0c1015;
 }


### PR DESCRIPTION
- Add info-label class to Name, A.k.a, Tech skills, Status labels
- Apply #27a888 color to labels matching schedule header style
- Translate streaming schedule from Spanish to English
- Change "Horario de Streams" to "Streaming Schedule"
- Change "Lunes - Viernes" to "Monday - Friday"
- Change "Sábados" to "Saturdays"