### PR TITLE
Reduce stream check interval to 15 seconds for faster detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,8 +149,8 @@
     // Verificar al cargar la página
     checkIfLive();
 
-    // Verificar cada 1 minuto (60000ms) en lugar de 5 minutos para detección más rápida
-    setInterval(checkIfLive, 60000);
+    // Verificar cada 15 segundos para detección casi inmediata
+    setInterval(checkIfLive, 15000);
 </script>
 </body>
 </html>


### PR DESCRIPTION
Previous interval of 1 minute was too slow for detecting live streams. Now the stream will appear on the page within 15 seconds of going live.