### PR TITLE
Posts 28/07 y 29/07 — AI Tooling

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,38 @@
 
         <section class="posts-section">
             <div class="posts-list" id="posts-list">
+                <article class="post-card" data-date="2026-07-29">
+                    <div class="post-meta">
+                        <span class="post-date">07/29/2026</span>
+                        <span class="post-category" data-en="AI Tooling" data-es="AI Tooling">AI Tooling</span>
+                    </div>
+                    <p class="post-message" data-en="Verified that subagents load shared skills, then rewrote my orchestrator so every subtask runs in its own terminal tab with its own model and reasoning effort. Lesson: a wrong cost assumption inside a prompt skews decisions for months without ever looking like a bug."
+                       data-es="Verifiqué que los subagentes cargan skills compartidas y reescribí mi orquestador para que cada subtarea corra en su propia tab con modelo y effort propios. Lección: una premisa de coste equivocada dentro de un prompt sesga decisiones durante meses sin parecer nunca un error.">
+                        Verifiqué que los subagentes cargan skills compartidas y reescribí mi orquestador para que cada subtarea corra en su propia tab con modelo y effort propios. Lección: una premisa de coste equivocada dentro de un prompt sesga decisiones durante meses sin parecer nunca un error.
+                    </p>
+                    <div class="post-tags">
+                        <span class="tag">ai</span>
+                        <span class="tag">opencode</span>
+                        <span class="tag">herdr</span>
+                        <span class="tag">automation</span>
+                    </div>
+                </article>
+                <article class="post-card" data-date="2026-07-28">
+                    <div class="post-meta">
+                        <span class="post-date">07/28/2026</span>
+                        <span class="post-category" data-en="AI Tooling" data-es="AI Tooling">AI Tooling</span>
+                    </div>
+                    <p class="post-message" data-en="Reworked my agentic coding setup: secrets out of config files into environment variables, and an 8KB instructions file split into skills that load on demand. Lesson: whatever loads every session gets paid for every session."
+                       data-es="Reorganicé mi setup de agentic coding: saqué los secretos de los archivos de configuración a variables de entorno y partí un archivo de instrucciones de 8KB en skills que cargan bajo demanda. Lección: lo que se carga en cada sesión se paga en cada sesión.">
+                        Reorganicé mi setup de agentic coding: saqué los secretos de los archivos de configuración a variables de entorno y partí un archivo de instrucciones de 8KB en skills que cargan bajo demanda. Lección: lo que se carga en cada sesión se paga en cada sesión.
+                    </p>
+                    <div class="post-tags">
+                        <span class="tag">ai</span>
+                        <span class="tag">claude</span>
+                        <span class="tag">opencode</span>
+                        <span class="tag">security</span>
+                    </div>
+                </article>
                 <article class="post-card" data-date="2026-07-23">
                     <div class="post-meta">
                         <span class="post-date">07/23/2026</span>


### PR DESCRIPTION
Dos posts generados desde el journal privado con la skill `journal-a-post`, revisados por el gate de fugas antes de abrir este PR.

### 28/07 · AI Tooling
> Reorganicé mi setup de agentic coding: saqué los secretos de los archivos de configuración a variables de entorno y partí un archivo de instrucciones de 8KB en skills que cargan bajo demanda. Lección: lo que se carga en cada sesión se paga en cada sesión.

`ai` `claude` `opencode` `security`

### 29/07 · AI Tooling
> Verifiqué que los subagentes cargan skills compartidas y reescribí mi orquestador para que cada subtarea corra en su propia tab con modelo y effort propios. Lección: una premisa de coste equivocada dentro de un prompt sesga decisiones durante meses sin parecer nunca un error.

`ai` `opencode` `herdr` `automation`

---

**Verificación de fugas:** `journal-post-gate.sh` ejecutado sobre cada post y sobre el `index.html` completo tras la inserción — limpio en ambos casos. Sin IDs de ticket, cuentas AWS, repos internos ni nombres del empleador.

**HTML:** etiquetas `<article>` balanceadas, orden cronológico correcto (29 → 28 → 23…).